### PR TITLE
Attempt to use VS Maven for all dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,17 +100,12 @@ allprojects {
     repositories {
         maven {
             name = "Valkyrien Skies Internal"
-            url = project.vs_maven_url
-            if (project.hasProperty('vs_maven_username') && project.hasProperty('vs_maven_url')) {
+            url = project.vs_maven_url ?: 'https://maven.valkyrienskies.org'
+            if (project.vs_maven_username && project.vs_maven_url) {
                 credentials {
-                    username = project.findProperty('vs_maven_username')
-                    password = project.findProperty('vs_maven_password')
+                    username = project.vs_maven_username
+                    password = project.vs_maven_url
                 }
-            }
-            content {
-                // this repository *only* contains artifacts with group "org.valkyrienskies"
-                includeGroup("org.valkyrienskies")
-                includeGroup("org.valkyrienskies.core")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,8 @@ architectury_version=1.31.61
 fabric_loader_version=0.14.5
 fabric_api_version=0.42.0+1.16
 forge_version=1.16.5-36.2.35
-vs_maven_url=https://maven.valkyrienskies.org/
 vs2_version=1.0.0+6780b41a57
+
+vs_maven_url=
+vs_maven_username=
+vs_maven_password=

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,17 @@
 pluginManagement {
     repositories {
+        maven {
+            name = "Valkyrien Skies Internal"
+
+            url = vs_maven_url ?: 'https://maven.valkyrienskies.org'
+
+            if (vs_maven_username && vs_maven_password) {
+                credentials {
+                    username = getProperty('vs_maven_username')
+                    password = getProperty('vs_maven_password')
+                }
+            }
+        }
         maven { url "https://maven.fabricmc.net/" }
         maven { url "https://maven.architectury.dev/" }
         maven { url "https://maven.minecraftforge.net/" }


### PR DESCRIPTION
current build configuration does not attempt to use VS Maven for all dependencies, which means it will not proxy/save them and if one of the 3rd party mavens we depend on (architectury, fabric, forge, and any others) goes down, so will the build. This remedies that.