### PR TITLE
Resolved helm soft-locks

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/ShipHelmBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/ShipHelmBlock.kt
@@ -29,6 +29,7 @@ import org.valkyrienskies.eureka.blockentity.ShipHelmBlockEntity
 import org.valkyrienskies.eureka.ship.EurekaShipControl
 import org.valkyrienskies.eureka.util.DirectionalShape
 import org.valkyrienskies.eureka.util.RotShapes
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod
 import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.getShipObjectManagingPos
 
@@ -58,8 +59,14 @@ class ShipHelmBlock(properties: Properties, val woodType: WoodType) : BaseEntity
         if (level.isClientSide) return
         level as ServerLevel
 
-        level.getShipManagingPos(pos)?.getAttachment<EurekaShipControl>()?.let {
-            it.helms -= 1
+        level.getShipManagingPos(pos)?.getAttachment<EurekaShipControl>()?.let { control ->
+
+            if (control.helms <= 1 && control.seatedPlayer?.vehicle?.type == ValkyrienSkiesMod.SHIP_MOUNTING_ENTITY_TYPE) {
+                control.seatedPlayer!!.unRide()
+                control.seatedPlayer = null
+            }
+
+            control.helms -= 1
         }
     }
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -87,6 +87,28 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
         return entity
     }
 
+    fun startRiding(player: Player, force: Boolean, blockPos: BlockPos, state: BlockState, level: ServerLevel): Boolean {
+
+        for (i in seats.size-1 downTo 0) {
+            if (!seats[i].isVehicle) {
+                seats[i].kill()
+                seats.removeAt(i)
+            } else if (!seats[i].isAlive) {
+                seats.removeAt(i)
+            }
+        }
+
+        val seat = spawnSeat(blockPos, blockState, level)
+        val ride = player.startRiding(seat, force)
+
+        if (ride) {
+            control?.seatedPlayer = player
+            seats.add(seat)
+        }
+
+        return ride;
+    }
+
     fun tick() {
         if (shouldDisassembleWhenPossible && ship?.getAttachment<EurekaShipControl>()?.canDisassemble == true) {
             this.disassemble()
@@ -138,16 +160,30 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
         control.aligning = !control.aligning
     }
 
+    override fun setRemoved() {
+
+        if (level?.isClientSide == false) {
+            for (i in seats.indices) {
+                seats[i].kill()
+            }
+            seats.clear()
+        }
+
+        super.setRemoved()
+    }
+
     fun sit(player: Player, force: Boolean = false): Boolean {
         // If player is already controlling the ship, open the helm menu
-        if (!force && player.vehicle?.type == ValkyrienSkiesMod.SHIP_MOUNTING_ENTITY_TYPE && control?.seatedPlayer == player)
+        if (!force && player.vehicle?.type == ValkyrienSkiesMod.SHIP_MOUNTING_ENTITY_TYPE && seats.contains(player.vehicle as ShipMountingEntity))
         {
             player.openMenu(this);
             return true;
         }
 
-        val seat = spawnSeat(blockPos, blockState, level as ServerLevel)
-        control?.seatedPlayer = player
-        return player.startRiding(seat, force)
+        //val seat = spawnSeat(blockPos, blockState, level as ServerLevel)
+        //control?.seatedPlayer = player
+        //return player.startRiding(seat, force)
+        return startRiding(player, force, blockPos, blockState, level as ServerLevel)
+
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -8,6 +8,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.TranslatableComponent
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.MenuProvider
+import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.inventory.AbstractContainerMenu
@@ -41,6 +42,7 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
     override var ship: ServerShip? = null // TODO ship is not being set in vs2?
         get() = field ?: (level as ServerLevel).getShipObjectManagingPos(this.blockPos)
     val control by shipValue<EurekaShipControl>()
+    val seats = mutableListOf<ShipMountingEntity>()
     val assembled get() = ship != null
     val aligning get() = control?.aligning ?: false
     var shouldDisassembleWhenPossible = false
@@ -137,6 +139,13 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
     }
 
     fun sit(player: Player, force: Boolean = false): Boolean {
+        // If player is already controlling the ship, open the helm menu
+        if (!force && player.vehicle?.type == ValkyrienSkiesMod.SHIP_MOUNTING_ENTITY_TYPE && control?.seatedPlayer == player)
+        {
+            player.openMenu(this);
+            return true;
+        }
+
         val seat = spawnSeat(blockPos, blockState, level as ServerLevel)
         control?.seatedPlayer = player
         return player.startRiding(seat, force)

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -367,7 +367,7 @@ class EurekaShipControl : ShipForcesInducer, ServerShipUser, Ticked {
     }
 
     private fun deleteIfEmpty() {
-        if (helms == 0 && floaters == 0 && anchors == 0 && balloons == 0) {
+        if (helms <= 0 && floaters <= 0 && anchors <= 0 && balloons <= 0) {
             ship?.saveAttachment<EurekaShipControl>(null)
         }
     }


### PR DESCRIPTION
* closes #125, closes #27, and closes #175
* Right-clicking on the helm while already controlling it will open the GUI instead of recreating the seat.