### PR TITLE
Removed duplicate clientSetup listener in 1.19

### DIFF
--- a/forge/src/main/java/org/valkyrienskies/eureka/forge/EurekaModForge.java
+++ b/forge/src/main/java/org/valkyrienskies/eureka/forge/EurekaModForge.java
@@ -36,7 +36,6 @@ public class EurekaModForge {
             MOD_BUS.addListener(this::clientSetup);
             MOD_BUS.addListener(this::onModelRegistry);
             MOD_BUS.addListener(this::onModelBaked);
-            MOD_BUS.addListener(this::clientSetup);
             MOD_BUS.addListener(this::entityRenderers);
         }
 


### PR DESCRIPTION
* removed duplicate of `MOD_BUS.addListener(this::clientSetup);`