### PR TITLE
Extra balloons now increases elevation speed

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -59,7 +59,14 @@ object EurekaConfig {
         // Sensitivity of the up/down impulse buttons.
         // TODO maybe should be moved to VS2 client-side config?
         @JsonSchema(description = "Vertical sensitivity up ascend/descend")
-        var impulseElevationRate = 7
+        var baseImpulseElevationRate = 1.0
+
+        @JsonSchema(description = "The max elevation speed boost gained by having extra extra balloons")
+        var balloonElevationMaxSpeed = 5.0
+
+        // Higher numbers make the ship accelerate to max speed faster
+        @JsonSchema(description = "Ascend and descend acceleration")
+        var elevationSnappiness = 1.0
 
         // Allow Eureka controlled ships to be affected by fluid drag
         @JsonSchema(description = "Allow Eureka controlled ships to be affected by fluid drag")

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -59,10 +59,10 @@ object EurekaConfig {
         // Sensitivity of the up/down impulse buttons.
         // TODO maybe should be moved to VS2 client-side config?
         @JsonSchema(description = "Vertical sensitivity up ascend/descend")
-        var baseImpulseElevationRate = 1.0
+        var baseImpulseElevationRate = 2.0
 
         @JsonSchema(description = "The max elevation speed boost gained by having extra extra balloons")
-        var balloonElevationMaxSpeed = 5.0
+        var balloonElevationMaxSpeed = 5.5
 
         // Higher numbers make the ship accelerate to max speed faster
         @JsonSchema(description = "Ascend and descend acceleration")

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -302,17 +302,13 @@ class EurekaShipControl : ShipForcesInducer, ServerShipUser, Ticked {
             physShip.applyInvariantForce(actualExtraForce)
             // endregion
 
-            // Smoothing for how the elevation scales as you approaches the balloonElevationMaxSpeed
-            val smoothing = 2.0
-
             // Player controlled elevation
             if (control.upImpulse != 0.0f) {
                 idealUpwardVel = Vector3d(0.0, 1.0, 0.0)
                     .mul(control.upImpulse.toDouble())
                     .mul(EurekaConfig.SERVER.baseImpulseElevationRate +
-
-                        (EurekaConfig.SERVER.balloonElevationMaxSpeed - smoothing /
-                        (balloonForceProvided / mass + (smoothing / EurekaConfig.SERVER.balloonElevationMaxSpeed)))
+                        // Smoothing for how the elevation scales as you approaches the balloonElevationMaxSpeed
+                        smoothing(2.0, EurekaConfig.SERVER.balloonElevationMaxSpeed, balloonForceProvided / mass)
                     )
             }
         }
@@ -379,9 +375,7 @@ class EurekaShipControl : ShipForcesInducer, ServerShipUser, Ticked {
     /**
      * f(x) = max - smoothing / (x + (smoothing / max))
      */
-    private fun smoothing(smoothing: Double, max: Double, x: Double): Double {
-        return (max - smoothing / (x + (smoothing / max)))
-    }
+    private fun smoothing(smoothing: Double, max: Double, x: Double): Double = max - smoothing / (x + (smoothing / max))
 
     companion object {
         fun getOrCreate(ship: ServerShip): EurekaShipControl {


### PR DESCRIPTION
You can play around with the smoothing function [here](https://www.geogebra.org/graphing/zfdrervv)

Extra balloon increases elevation speed. To combat this extra bonus speed, impulseElevationRate was nerfed.
As a result, having just enough balloons will resolve at a slow elevation speed.