### PR TITLE
Limit the BFS depth

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -199,5 +199,8 @@ object EurekaConfig {
 
         @JsonSchema(description = "Whether or not disassembly is permitted")
         val allowDisassembly = true
+
+        @JsonSchema(description = "Maximum number of blocks allowed in a ship")
+        val maxShipBlocks = 262144
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -201,6 +201,6 @@ object EurekaConfig {
         val allowDisassembly = true
 
         @JsonSchema(description = "Maximum number of blocks allowed in a ship. Set to 0 for no limit")
-        val maxShipBlocks = 64*64*64
+        val maxShipBlocks = 32*32*32
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -201,6 +201,6 @@ object EurekaConfig {
         val allowDisassembly = true
 
         @JsonSchema(description = "Maximum number of blocks allowed in a ship")
-        val maxShipBlocks = 262144
+        val maxShipBlocks = 64*64*64
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -200,7 +200,7 @@ object EurekaConfig {
         @JsonSchema(description = "Whether or not disassembly is permitted")
         val allowDisassembly = true
 
-        @JsonSchema(description = "Maximum number of blocks allowed in a ship")
+        @JsonSchema(description = "Maximum number of blocks allowed in a ship. Set to 0 for no limit")
         val maxShipBlocks = 64*64*64
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -1,10 +1,12 @@
 package org.valkyrienskies.eureka.blockentity
 
+import net.minecraft.Util
 import net.minecraft.commands.arguments.EntityAnchorArgument
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction.Axis
 import net.minecraft.core.Registry
 import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.TextComponent
 import net.minecraft.network.chat.TranslatableComponent
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.MenuProvider
@@ -116,17 +118,21 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
     }
 
     // Needs to get called server-side
-    fun assemble() {
+    fun assemble(player: Player) {
         val level = level as ServerLevel
 
         // Check the block state before assembling to avoid creating an empty ship
         val blockState = level.getBlockState(blockPos)
         if (blockState.block !is ShipHelmBlock) return
 
-        ShipAssembler.collectBlocks(
+        val builtShip = ShipAssembler.collectBlocks(
             level,
             blockPos
         ) { !it.isAir && !EurekaConfig.SERVER.blockBlacklist.contains(Registry.BLOCK.getKey(it.block).toString()) }
+
+        if (builtShip == null){
+            player.sendMessage(TextComponent("Ship is too big! Max size is ${EurekaConfig.SERVER.maxShipBlocks} blocks"), Util.NIL_UUID)
+        }
     }
 
     fun disassemble() {

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -132,7 +132,7 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
         ) { !it.isAir && !EurekaConfig.SERVER.blockBlacklist.contains(Registry.BLOCK.getKey(it.block).toString()) }
 
         if (builtShip == null){
-            player.sendMessage(TextComponent("Ship is too big! Max size is ${EurekaConfig.SERVER.maxShipBlocks} blocks"), Util.NIL_UUID)
+            player.sendMessage(TextComponent("Ship is too big! Max size is ${EurekaConfig.SERVER.maxShipBlocks} blocks (changable in the config)"), Util.NIL_UUID)
             logger.warn("Failed to assemble ship for ${player.name.string}")
         }
     }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -133,7 +133,7 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
 
         if (builtShip == null){
             player.sendMessage(TextComponent("Ship is too big! Max size is ${EurekaConfig.SERVER.maxShipBlocks} blocks"), Util.NIL_UUID)
-            logger.warn("${player.name.string} tried to assemble a ship that was too big")
+            logger.warn("Failed to assemble ship for ${player.name.string}")
         }
     }
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -26,6 +26,7 @@ import org.valkyrienskies.core.api.ships.ServerShip
 import org.valkyrienskies.core.api.ships.getAttachment
 import org.valkyrienskies.core.impl.api.ServerShipProvider
 import org.valkyrienskies.core.impl.api.shipValue
+import org.valkyrienskies.core.impl.util.logger
 import org.valkyrienskies.eureka.EurekaBlockEntities
 import org.valkyrienskies.eureka.EurekaConfig
 import org.valkyrienskies.eureka.block.ShipHelmBlock
@@ -132,6 +133,7 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
 
         if (builtShip == null){
             player.sendMessage(TextComponent("Ship is too big! Max size is ${EurekaConfig.SERVER.maxShipBlocks} blocks"), Util.NIL_UUID)
+            logger.warn("${player.name.string} tried to assemble a ship that was too big")
         }
     }
 
@@ -192,4 +194,5 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
         return startRiding(player, force, blockPos, blockState, level as ServerLevel)
 
     }
+    private val logger by logger()
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/gui/shiphelm/ShipHelmScreenMenu.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/gui/shiphelm/ShipHelmScreenMenu.kt
@@ -22,7 +22,7 @@ class ShipHelmScreenMenu(syncId: Int, playerInv: Inventory, val blockEntity: Shi
         if (blockEntity == null) return false
 
         if (id == 0 && !assembled && !player.level.isClientSide) {
-            blockEntity.assemble()
+            blockEntity.assemble(player)
             return true
         }
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -178,7 +178,7 @@ object ShipAssembler {
                 }
             }
             if (blocks.size > EurekaConfig.SERVER.maxShipBlocks) {
-                logger.info("Stopped ship assembly by: too many blocks")
+                logger.info("Stopped ship assembly due too many blocks")
                 return false
             }
         }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -33,12 +33,16 @@ import kotlin.math.round
 import kotlin.math.sign
 
 object ShipAssembler {
-    fun collectBlocks(level: ServerLevel, center: BlockPos, predicate: (BlockState) -> Boolean): ServerShip {
+    fun collectBlocks(level: ServerLevel, center: BlockPos, predicate: (BlockState) -> Boolean): ServerShip? {
         val blocks = DenseBlockPosSet()
 
         blocks.add(center.toJOML())
-        bfs(level, center, blocks, predicate)
-        return createNewShipWithBlocks(center, blocks, level)
+        val result = bfs(level, center, blocks, predicate)
+        if (result) {
+            return createNewShipWithBlocks(center, blocks, level)
+        } else {
+            return null
+        }
     }
 
     private fun roundToNearestMultipleOf(number: Double, multiple: Double) = multiple * round(number / multiple)
@@ -154,7 +158,7 @@ object ShipAssembler {
         start: BlockPos,
         blocks: DenseBlockPosSet,
         predicate: (BlockState) -> Boolean
-    ) {
+    ):Boolean {
 
         val blacklist = DenseBlockPosSet()
         val stack = ObjectArrayList<BlockPos>()
@@ -173,7 +177,12 @@ object ShipAssembler {
                     }
                 }
             }
+            if (blocks.size > EurekaConfig.SERVER.maxShipBlocks) {
+                return false
+            }
         }
+        logger.info("Found ${blocks.size} blocks, out of ${EurekaConfig.SERVER.maxShipBlocks} allowed")
+        return true;
     }
 
     private fun directions(center: BlockPos, lambda: (BlockPos) -> Unit) {

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -178,11 +178,12 @@ object ShipAssembler {
                 }
             }
             if (blocks.size > EurekaConfig.SERVER.maxShipBlocks) {
+                logger.info("Stopped ship assembly by: too many blocks")
                 return false
             }
         }
-        logger.info("Found ${blocks.size} blocks, out of ${EurekaConfig.SERVER.maxShipBlocks} allowed")
-        return true;
+        logger.info("Assembled ship with ${blocks.size} blocks, out of ${EurekaConfig.SERVER.maxShipBlocks} allowed")
+        return true
     }
 
     private fun directions(center: BlockPos, lambda: (BlockPos) -> Unit) {

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -177,12 +177,14 @@ object ShipAssembler {
                     }
                 }
             }
-            if (blocks.size > EurekaConfig.SERVER.maxShipBlocks) {
+            if ((EurekaConfig.SERVER.maxShipBlocks > 0) and (blocks.size > EurekaConfig.SERVER.maxShipBlocks)) {
                 logger.info("Stopped ship assembly due too many blocks")
                 return false
             }
         }
-        logger.info("Assembled ship with ${blocks.size} blocks, out of ${EurekaConfig.SERVER.maxShipBlocks} allowed")
+        if (EurekaConfig.SERVER.maxShipBlocks > 0){
+            logger.info("Assembled ship with ${blocks.size} blocks, out of ${EurekaConfig.SERVER.maxShipBlocks} allowed")
+        }
         return true
     }
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -158,7 +158,7 @@ object ShipAssembler {
         start: BlockPos,
         blocks: DenseBlockPosSet,
         predicate: (BlockState) -> Boolean
-    ):Boolean {
+    ): Boolean {
 
         val blacklist = DenseBlockPosSet()
         val stack = ObjectArrayList<BlockPos>()


### PR DESCRIPTION
The block blacklist does a good job of preventing the server from getting stuck in BFS, but modded blocks could cause runaways. (This happened in a server I help run - a ship was connected to a seafloor made of salt blocks by another mods Kelp. Attempting to assemble the ship without removing the kelp crashed the server)

This PR adds a maxShipBlocks config value, which allows the BFS function to quit if there are too many blocks, preventing a server crash/slowdown.

I'm not sure what a good default value should be - right now, it's 64^3. As is, the limit is just number-of-blocks, but it could be modified to limit the bounding box instead (keep track of the farthest blocks found in BFS, and limit with that instead)