### PR TITLE
Fix issue where rotating the ship sometimes causes blocks to rotate in odd ways

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,10 @@ allprojects {
     repositories {
         mavenLocal()
         maven {
+            name = 'Kotlin for Forge'
+            url = 'https://thedarkcolour.github.io/KotlinForForge/'
+        }
+        maven {
             name = "Valkyrien Skies Internal"
             url = project.vs_maven_url ?: 'https://maven.valkyrienskies.org'
             if (project.vs_maven_username && project.vs_maven_password) {

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -2,7 +2,6 @@ package org.valkyrienskies.eureka.blockentity
 
 import net.minecraft.commands.arguments.EntityAnchorArgument
 import net.minecraft.core.BlockPos
-import net.minecraft.core.Direction
 import net.minecraft.core.Direction.Axis
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.network.chat.Component
@@ -12,13 +11,11 @@ import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.inventory.AbstractContainerMenu
 import net.minecraft.world.level.block.HorizontalDirectionalBlock
-import net.minecraft.world.level.block.Rotation
 import net.minecraft.world.level.block.StairBlock
 import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.block.state.properties.BlockStateProperties.HORIZONTAL_FACING
 import net.minecraft.world.level.block.state.properties.Half
-import org.joml.AxisAngle4d
 import org.joml.Vector3d
 import org.joml.Vector3dc
 import org.valkyrienskies.core.api.ships.ServerShip
@@ -35,9 +32,6 @@ import org.valkyrienskies.mod.common.entity.ShipMountingEntity
 import org.valkyrienskies.mod.common.getShipObjectManagingPos
 import org.valkyrienskies.mod.common.util.toDoubles
 import org.valkyrienskies.mod.common.util.toJOMLD
-import kotlin.math.PI
-import kotlin.math.absoluteValue
-import kotlin.math.sign
 
 class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
     BlockEntity(EurekaBlockEntities.SHIP_HELM.get(), pos, state), MenuProvider {

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -50,13 +50,11 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
 
     private var angleUntilAligned = 0.0
     private var positionUntilAligned = Vector3d()
-    private var alignTarget = 0
     val canDisassemble
         get() = ship != null &&
             disassembling &&
             abs(angleUntilAligned) < DISASSEMBLE_THRESHOLD &&
             positionUntilAligned.distanceSquared(this.ship!!.transform.positionInWorld) < 4.0
-    val aligningTo: Direction get() = Direction.from2DDataValue(alignTarget)
     var consumed = 0f
         private set
 
@@ -132,7 +130,7 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
         val invRotation = physShip.poseVel.rot.invert(Quaterniond())
         val invRotationAxisAngle = AxisAngle4d(invRotation)
         // Floor makes a number 0 to 3, which corresponds to direction
-        alignTarget = floor((invRotationAxisAngle.angle / (PI * 0.5)) + 4.5).toInt() % 4
+        val alignTarget = floor((invRotationAxisAngle.angle / (PI * 0.5)) + 4.5).toInt() % 4
         angleUntilAligned = (alignTarget.toDouble() * (0.5 * PI)) - invRotationAxisAngle.angle
         if (disassembling) {
             val pos = ship.transform.positionInWorld

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -77,11 +77,11 @@ object ShipAssembler {
         val eps = 0.001
         if (axis.angle < eps)
             return Rotation.NONE
-        else if (axis.angle - PI / 2.0 < eps)
+        else if ((axis.angle - PI / 2.0).absoluteValue < eps)
             return Rotation.COUNTERCLOCKWISE_90
-        else if (axis.angle - PI < eps)
+        else if ((axis.angle - PI).absoluteValue < eps)
             return Rotation.CLOCKWISE_180
-        else if (axis.angle - 3.0 * PI / 2.0 < eps)
+        else if ((axis.angle - 3.0 * PI / 2.0).absoluteValue < eps)
             return Rotation.CLOCKWISE_90
         else {
             logger.warn("failed to convert $axis into a rotation")

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -47,7 +47,7 @@ object ShipAssembler {
     private fun roundToNearestMultipleOf(number: Double, multiple: Double) = multiple * round(number / multiple)
 
     // modified from https://gamedev.stackexchange.com/questions/83601/from-3d-rotation-snap-to-nearest-90-directions
-    private fun snapRotation(direction: AxisAngle4d): AxisAngle4d {
+    fun snapRotation(direction: AxisAngle4d): AxisAngle4d {
         val x = abs(direction.x)
         val y = abs(direction.y)
         val z = abs(direction.z)
@@ -62,7 +62,7 @@ object ShipAssembler {
         }
     }
 
-    fun unfillShip(level: ServerLevel, ship: ServerShip, direction: Direction, shipCenter: BlockPos, center: BlockPos) {
+    fun unfillShip(level: ServerLevel, ship: ServerShip, rotation: Rotation, shipCenter: BlockPos, center: BlockPos) {
         ship.isStatic = true
 
         // ship's rotation rounded to nearest 90*
@@ -75,18 +75,6 @@ object ShipAssembler {
         }
 
         val alloc0 = Vector3d()
-
-        // Direction comes from direction ship is aligning to
-        // We can assume that the ship in shipspace is always facing north, because it has to be
-        val rotation: Rotation = when (direction) {
-            Direction.SOUTH -> Rotation.NONE // Bug in Direction.from2DDataValue() can return south/north as opposite
-            Direction.NORTH -> Rotation.CLOCKWISE_180
-            Direction.EAST -> Rotation.CLOCKWISE_90
-            Direction.WEST -> Rotation.COUNTERCLOCKWISE_90
-            else -> {
-                Rotation.NONE
-            }
-        }
 
         val chunksToBeUpdated = mutableMapOf<ChunkPos, Pair<ChunkPos, ChunkPos>>()
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/util/ShipAssembler.kt
@@ -26,10 +26,7 @@ import org.valkyrienskies.mod.util.logger
 import org.valkyrienskies.mod.util.relocateBlock
 import org.valkyrienskies.mod.util.updateBlock
 import kotlin.collections.set
-import kotlin.math.PI
-import kotlin.math.abs
-import kotlin.math.round
-import kotlin.math.sign
+import kotlin.math.*
 
 object ShipAssembler {
     fun collectBlocks(level: ServerLevel, center: BlockPos, predicate: (BlockState) -> Boolean): ServerShip? {
@@ -47,7 +44,7 @@ object ShipAssembler {
     private fun roundToNearestMultipleOf(number: Double, multiple: Double) = multiple * round(number / multiple)
 
     // modified from https://gamedev.stackexchange.com/questions/83601/from-3d-rotation-snap-to-nearest-90-directions
-    fun snapRotation(direction: AxisAngle4d): AxisAngle4d {
+    private fun snapRotation(direction: AxisAngle4d): AxisAngle4d {
         val x = abs(direction.x)
         val y = abs(direction.y)
         val z = abs(direction.z)
@@ -62,8 +59,43 @@ object ShipAssembler {
         }
     }
 
-    fun unfillShip(level: ServerLevel, ship: ServerShip, rotation: Rotation, shipCenter: BlockPos, center: BlockPos) {
+    private fun rotationFromAxisAngle(axis: AxisAngle4d): Rotation {
+        if (axis.y.absoluteValue < 0.1) {
+            // if the axis isn't Y, either we're tilted up/down (which should not happen often) or we haven't moved and it's
+            // along the z axis with a magnitude of 0 for some reason. In these cases, we don't rotate.
+            return Rotation.NONE
+        }
+
+        // normalize into counterclockwise rotation (i.e. positive y-axis, according to testing + right hand rule)
+        if (axis.y.sign < 0.0) {
+            axis.y = 1.0
+            // the angle is always positive and < 2pi coming in
+            axis.angle = 2.0 * PI - axis.angle
+            axis.angle %= (2.0 * PI)
+        }
+
+        val eps = 0.001
+        if (axis.angle < eps)
+            return Rotation.NONE
+        else if (axis.angle - PI / 2.0 < eps)
+            return Rotation.COUNTERCLOCKWISE_90
+        else if (axis.angle - PI < eps)
+            return Rotation.CLOCKWISE_180
+        else if (axis.angle - 3.0 * PI / 2.0 < eps)
+            return Rotation.CLOCKWISE_90
+        else {
+            logger.warn("failed to convert $axis into a rotation")
+            return Rotation.NONE
+        }
+    }
+
+    fun unfillShip(level: ServerLevel, ship: ServerShip, shipCenter: BlockPos, center: BlockPos) {
         ship.isStatic = true
+
+        val rotation: Rotation = ship.transform.shipToWorldRotation
+            .let(::AxisAngle4d)
+            .let(ShipAssembler::snapRotation)
+            .let(::rotationFromAxisAngle)
 
         // ship's rotation rounded to nearest 90*
         val shipToWorld = ship.transform.run {


### PR DESCRIPTION
Fixes #271, #193, #185

Changes:
- Added KotlinForForge to the build.gradle, because I couldn't successfully build until I did so
- Removed `EurekaShipControl.aligningTo` and `alignTarget` fields.
  - `aligningTo` was only used for rotating blocks and was extremely buggy, so it was removed.
  - `alignTarget` was changed to a local and appears to work correctly for its main purpose, but not for producing `aligningTo`.
- Removed `direction` parameter on `unfillShip` to instead derive the block rotation from `ship.transform.shipToWorldRotation`, which works consistently and correctly after some processing into a `Rotation`.