### PR TITLE
Fix issue where explosions do not affect ship buoyancy

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/AnchorBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/AnchorBlock.kt
@@ -91,8 +91,9 @@ class AnchorBlock :
         attachment.anchorsActive += if (bl) 1 else 0
     }
 
-    override fun destroy(level: LevelAccessor, pos: BlockPos, state: BlockState) {
-        super.destroy(level, pos, state)
+    override fun onRemove(state: BlockState, level: Level, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
+        super.onRemove(state, level, pos, newState, isMoving)
+
         if (level.isClientSide) return
         level as ServerLevel
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -33,8 +33,8 @@ class BalloonBlock(properties: Properties) : Block(properties) {
         EurekaShipControl.getOrCreate(ship).balloons += 1
     }
 
-    override fun destroy(level: LevelAccessor, pos: BlockPos, state: BlockState) {
-        super.destroy(level, pos, state)
+    override fun onRemove(state: BlockState, level: Level, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
+        super.onRemove(state, level, pos, newState, isMoving)
 
         if (level.isClientSide) return
         level as ServerLevel

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/FloaterBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/FloaterBlock.kt
@@ -62,8 +62,8 @@ class FloaterBlock : Block(
         level.setBlock(pos, state.setValue(POWER, signal), 2)
     }
 
-    override fun destroy(level: LevelAccessor, pos: BlockPos, state: BlockState) {
-        super.destroy(level, pos, state)
+    override fun onRemove(state: BlockState, level: Level, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
+        super.onRemove(state, level, pos, newState, isMoving)
 
         if (level.isClientSide) return
         level as ServerLevel

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/ShipHelmBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/ShipHelmBlock.kt
@@ -54,8 +54,8 @@ class ShipHelmBlock(properties: Properties, val woodType: WoodType) : BaseEntity
         EurekaShipControl.getOrCreate(ship).helms += 1
     }
 
-    override fun destroy(level: LevelAccessor, pos: BlockPos, state: BlockState) {
-        super.destroy(level, pos, state)
+    override fun onRemove(state: BlockState, level: Level, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
+        super.onRemove(state, level, pos, newState, isMoving)
 
         if (level.isClientSide) return
         level as ServerLevel


### PR DESCRIPTION
Fixes issue #308.

### Changes:
- Replaced instances of `Block::destroy()` for `BlockBehaviour::remove()` for Helm, Floater, Anchor and Balloon blocks. The new method is called any time a block is removed, whereas the old method seemed to only be called when a block was removed by a player.

### Run through of reproduction steps to verify:
Steps ran as expected.
Note that both ships are on the floor.

![2024-03-14_12 29 46](https://github.com/ValkyrienSkies/Eureka/assets/35272503/5deebf83-9453-443a-a006-e7324720123f)
