### PR TITLE
Merged block orientation not respected when disassembling a ship fix from #315

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/blockentity/ShipHelmBlockEntity.kt
@@ -87,7 +87,6 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
     }
 
     fun startRiding(player: Player, force: Boolean, blockPos: BlockPos, state: BlockState, level: ServerLevel): Boolean {
-
         for (i in seats.size - 1 downTo 0) {
             if (!seats[i].isVehicle) {
                 seats[i].kill()
@@ -129,7 +128,7 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
         ) { !it.isAir && !EurekaConfig.SERVER.blockBlacklist.contains(Registry.BLOCK.getKey(it.block).toString()) }
 
         if (builtShip == null) {
-            player.sendMessage(TextComponent("Ship is too big! Max size is ${EurekaConfig.SERVER.maxShipBlocks} blocks (changable in the config)"), Util.NIL_UUID)
+            player.sendMessage(TextComponent("Ship is too big! Max size is ${EurekaConfig.SERVER.maxShipBlocks} blocks (changeable in the config)"), Util.NIL_UUID)
             logger.warn("Failed to assemble ship for ${player.name.string}")
         }
     }
@@ -151,7 +150,6 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
         ShipAssembler.unfillShip(
             level as ServerLevel,
             ship,
-            control.aligningTo,
             this.blockPos,
             BlockPos(inWorld.x, inWorld.y, inWorld.z)
         )
@@ -166,7 +164,6 @@ class ShipHelmBlockEntity(pos: BlockPos, state: BlockState) :
     }
 
     override fun setRemoved() {
-
         if (level?.isClientSide == false) {
             for (i in seats.indices) {
                 seats[i].kill()

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -46,13 +46,11 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
 
     private var angleUntilAligned = 0.0
     private var positionUntilAligned = Vector3d()
-    private var alignTarget = 0
     val canDisassemble
         get() = ship != null &&
             disassembling &&
             abs(angleUntilAligned) < DISASSEMBLE_THRESHOLD &&
             positionUntilAligned.distanceSquared(this.ship!!.transform.positionInWorld) < 4.0
-    val aligningTo: Direction get() = Direction.from2DDataValue(alignTarget)
     var consumed = 0f
         private set
 
@@ -131,7 +129,7 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
         val invRotation = physShip.poseVel.rot.invert(Quaterniond())
         val invRotationAxisAngle = AxisAngle4d(invRotation)
         // Floor makes a number 0 to 3, which corresponds to direction
-        alignTarget = floor((invRotationAxisAngle.angle / (PI * 0.5)) + 4.5).toInt() % 4
+        val alignTarget = floor((invRotationAxisAngle.angle / (PI * 0.5)) + 4.5).toInt() % 4
         angleUntilAligned = (alignTarget.toDouble() * (0.5 * PI)) - invRotationAxisAngle.angle
         if (disassembling) {
             val pos = ship.transform.positionInWorld


### PR DESCRIPTION
* add kotlin for forge to build.gradle so forge can build

* use ship rotation instead of buggy `aligningTo`

* update shipAssembler to take a rotation and make snapRotation public

* move logic into ShipAssembler

* remove buggy aligningTo, demote alignTarget to a local

* fix float comparisons

* Removed unnecessary imports (millennIumAMbiguity)