### PR TITLE
Engine boost

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -46,6 +46,15 @@ object EurekaConfig {
         @JsonSchema(description = "Fuel burn time multiplier")
         val engineFuelMultiplier = 2f
 
+        @JsonSchema(description = "Extra engine power for when having multiple engines per engine")
+        val engineBoost = 0.2
+
+        @JsonSchema(description = "At what amount of engines the boost will start taking effect")
+        val engineBoostOffset = 2.5
+
+        @JsonSchema(description = "The final linear boost will be raised to the power of 2, and the result of the delta is multiple by this value")
+        val engineBoostExponentialPower = 0.000001
+
         @JsonSchema(description = "Max speed of a ship without boosting")
         val maxCasualSpeed = 15.0
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -314,6 +314,10 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
         val forwardForce = Vector3d(baseForwardVel).sub(velOrthogonalToPlayerUp).mul(mass10)
 
         if (extraForceLinear != 0.0) {
+            // engine boost
+            val boost = max((extraForceLinear - EurekaConfig.SERVER.enginePowerLinear * EurekaConfig.SERVER.engineBoostOffset) * EurekaConfig.SERVER.engineBoost, 0.0);
+            extraForceLinear += boost + boost * boost * EurekaConfig.SERVER.engineBoostExponentialPower;
+
             // This is the maximum speed we want to go in any scenario (when not sprinting)
             val idealForwardVel = Vector3d(forwardVector).mul(EurekaConfig.SERVER.maxCasualSpeed)
             val idealForwardForce = Vector3d(idealForwardVel).sub(velOrthogonalToPlayerUp).mul(mass10)


### PR DESCRIPTION
Additional efficacy for having multiple engines.

It will work like this:
* 1 engines: 0% boost
* 2 engines: 0% boost
* 3 engines: 3.4% boost
* 4 engines: 8.7% boost
* 5 engines: 12.8% boost
* 6 engines: 15.8% boost

This means that with 6 engines, you have close to the relevant power output of 7 engines.
With 9 engines, it would be over 11 engines of power.

---

Here is a graph, note that one engine produces 500000 power as of writing this.

this graph is for the boost excluding the base power.
negative numbers will be rounded to zero in the actual function.

![image](https://github.com/ValkyrienSkies/Eureka/assets/37588844/276e3fda-b5f2-4880-b153-ab054b6ac16b)
![image](https://github.com/ValkyrienSkies/Eureka/assets/37588844/4918258b-f71b-43ef-be0e-6dd35e6a5256)
