### PR TITLE
Config to require engines to make a ship fly/float with balloons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ classes/
 .vscode
 .settings
 *.launch
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ classes/
 .vscode
 .settings
 *.launch
-.DS_Store

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -37,6 +37,9 @@ object EurekaConfig {
         @JsonSchema(description = "Pause fuel consumption and power when block is powered")
         val engineRedstoneBehaviorPause = false
 
+        @JsonSchema(description = "Flying ships require an active engine")
+        val flightRequiresEngine = false
+
         @JsonSchema(description = "Avoids consuming fuel when heat is 100%")
         val engineFuelSaving = false
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -40,6 +40,12 @@ object EurekaConfig {
         @JsonSchema(description = "Flying ships require an active engine")
         val flightRequiresEngine = false
 
+        @JsonSchema(description = "Heat percentage the engine needs to be at to give balloons full power (Only if flying requires an engine)")
+        val flightEnginePercentage = 75
+
+        @JsonSchema(description = "Number of engines needed to give balloons full power at the Flight Engine Percentage")
+        val flightMaxEngines = 2
+
         @JsonSchema(description = "Avoids consuming fuel when heat is 100%")
         val engineFuelSaving = false
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -37,11 +37,8 @@ object EurekaConfig {
         @JsonSchema(description = "Pause fuel consumption and power when block is powered")
         val engineRedstoneBehaviorPause = false
 
-        @JsonSchema(description = "Flying ships require an active engine")
-        val flightRequiresEngine = false
-
-        @JsonSchema(description = "Number of Balloons a single engine can power")
-        val maxBalloonsPerEngine = 5
+        @JsonSchema(description = "Number of Balloons a single engine can power. 0 disables the feature")
+        val maxBalloonsPerEngine = 0
 
         @JsonSchema(description = "Avoids consuming fuel when heat is 100%")
         val engineFuelSaving = false

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -40,11 +40,8 @@ object EurekaConfig {
         @JsonSchema(description = "Flying ships require an active engine")
         val flightRequiresEngine = false
 
-        @JsonSchema(description = "Heat percentage the engine needs to be at to give balloons full power (Only if flying requires an engine)")
-        val flightEnginePercentage = 75
-
-        @JsonSchema(description = "Number of engines needed to give balloons full power at the Flight Engine Percentage")
-        val flightMaxEngines = 2
+        @JsonSchema(description = "Number of Balloons a single engine can power")
+        val maxBalloonsPerEngine = 5
 
         @JsonSchema(description = "Avoids consuming fuel when heat is 100%")
         val engineFuelSaving = false

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -96,7 +96,12 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
         val moiTensor = physShip.momentOfInertia
         val omega: Vector3dc = physShip.omega
         val vel: Vector3dc = physShip.velocity
-        val balloonForceProvided = balloons * forcePerBalloon
+
+        var balloonForceProvided = 0.0
+        // Only calculate balloons if we have an active engine or if config is disabled
+        if (extraForceLinear != 0.0 || !EurekaConfig.SERVER.flightRequiresEngine) {
+            balloonForceProvided = balloons * forcePerBalloon
+        }
 
         val buoyantFactorPerFloater = min(
             EurekaConfig.SERVER.floaterBuoyantFactorPerKg / 15.0 / mass,
@@ -336,7 +341,10 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
     private fun getPlayerUpwardVel(control: ControlData, mass: Double): Vector3d {
         if (control.upImpulse != 0.0f) {
 
-            val balloonForceProvided = balloons * forcePerBalloon
+            var balloonForceProvided = 0.0
+            if (extraForceLinear != 0.0 || !EurekaConfig.SERVER.flightRequiresEngine) {
+                balloonForceProvided = balloons * forcePerBalloon
+            }
 
             return Vector3d(0.0, 1.0, 0.0)
                 .mul(control.upImpulse.toDouble())

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -97,10 +97,16 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
         val omega: Vector3dc = physShip.omega
         val vel: Vector3dc = physShip.velocity
 
-        var balloonForceProvided = 0.0
-        // Only calculate balloons if we have an active engine or if config is disabled
-        if (extraForceLinear != 0.0 || !EurekaConfig.SERVER.flightRequiresEngine) {
-            balloonForceProvided = balloons * forcePerBalloon
+        var balloonForceProvided = balloons * forcePerBalloon
+        if ( EurekaConfig.SERVER.flightRequiresEngine ) {
+            balloonForceProvided = if (extraForceLinear == 0.0) {
+                0.0 // Divide by 0 case
+            } else {
+                (balloons * forcePerBalloon) * min(
+                    1.0,
+                    (extraForceLinear / ( EurekaConfig.SERVER.enginePowerLinear * EurekaConfig.SERVER.flightMaxEngines ) ) * (100 / EurekaConfig.SERVER.flightEnginePercentage)
+                )
+            }
         }
 
         val buoyantFactorPerFloater = min(
@@ -341,9 +347,16 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
     private fun getPlayerUpwardVel(control: ControlData, mass: Double): Vector3d {
         if (control.upImpulse != 0.0f) {
 
-            var balloonForceProvided = 0.0
-            if (extraForceLinear != 0.0 || !EurekaConfig.SERVER.flightRequiresEngine) {
-                balloonForceProvided = balloons * forcePerBalloon
+            var balloonForceProvided = balloons * forcePerBalloon
+            if ( EurekaConfig.SERVER.flightRequiresEngine ) {
+                balloonForceProvided = if (extraForceLinear == 0.0) {
+                    0.0 // Divide by 0 case
+                } else {
+                    (balloons * forcePerBalloon) * min(
+                        1.0,
+                        (extraForceLinear / ( EurekaConfig.SERVER.enginePowerLinear * EurekaConfig.SERVER.flightMaxEngines ) ) * (100 / EurekaConfig.SERVER.flightEnginePercentage)
+                    )
+                }
             }
 
             return Vector3d(0.0, 1.0, 0.0)

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -99,12 +99,12 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
 
         var balloonForceProvided = balloons * forcePerBalloon
         if ( EurekaConfig.SERVER.flightRequiresEngine ) {
-            balloonForceProvided = if (extraForceLinear == 0.0) {
-                0.0 // Divide by 0 case
+            balloonForceProvided = if (extraForceLinear == 0.0 || balloons == 0) {
+                0.0 // Prevent Divide by 0 case
             } else {
-                (balloons * forcePerBalloon) * min(
+                balloonForceProvided * min(
                     1.0,
-                    (extraForceLinear / ( EurekaConfig.SERVER.enginePowerLinear * EurekaConfig.SERVER.flightMaxEngines ) ) * (100 / EurekaConfig.SERVER.flightEnginePercentage)
+                    ( extraForceLinear * EurekaConfig.SERVER.maxBalloonsPerEngine ) / ( EurekaConfig.SERVER.enginePowerLinear * balloons )
                 )
             }
         }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -97,12 +97,12 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
         val omega: Vector3dc = physShip.omega
         val vel: Vector3dc = physShip.velocity
 
-        var balloonForceProvided = balloons * forcePerBalloon
+        var engineScaledballoonForceProvided = balloons * forcePerBalloon
         if ( EurekaConfig.SERVER.flightRequiresEngine ) {
-            balloonForceProvided = if (extraForceLinear == 0.0 || balloons == 0) {
+            engineScaledballoonForceProvided = if (extraForceLinear == 0.0 || balloons == 0) {
                 0.0 // Prevent Divide by 0 case
             } else {
-                balloonForceProvided * min(
+                engineScaledballoonForceProvided * min(
                     1.0,
                     ( extraForceLinear * EurekaConfig.SERVER.maxBalloonsPerEngine ) / ( EurekaConfig.SERVER.enginePowerLinear * balloons )
                 )
@@ -211,7 +211,7 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
                 mass * EurekaConfig.SERVER.elevationSnappiness
 
         physShip.applyInvariantForce(Vector3d(0.0,
-            min(balloonForceProvided, max(idealUpwardForce, 0.0)) +
+            min(engineScaledballoonForceProvided, max(idealUpwardForce, 0.0)) +
             // Add drag to the y-component
             vel.y() * -mass,
             0.0)

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -96,17 +96,13 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
         val moiTensor = physShip.momentOfInertia
         val omega: Vector3dc = physShip.omega
         val vel: Vector3dc = physShip.velocity
+        var balloonForceProvided = balloons * forcePerBalloon
 
-        var engineScaledballoonForceProvided = balloons * forcePerBalloon
-        if ( EurekaConfig.SERVER.flightRequiresEngine ) {
-            engineScaledballoonForceProvided = if (extraForceLinear == 0.0 || balloons == 0) {
-                0.0 // Prevent Divide by 0 case
-            } else {
-                engineScaledballoonForceProvided * min(
-                    1.0,
-                    ( extraForceLinear * EurekaConfig.SERVER.maxBalloonsPerEngine ) / ( EurekaConfig.SERVER.enginePowerLinear * balloons )
-                )
-            }
+        if (EurekaConfig.SERVER.maxBalloonsPerEngine > 0) {
+            balloonForceProvided *= min(
+                1.0,
+                ( extraForceLinear * EurekaConfig.SERVER.maxBalloonsPerEngine ) / ( EurekaConfig.SERVER.enginePowerLinear * balloons )
+            )
         }
 
         val buoyantFactorPerFloater = min(
@@ -211,7 +207,7 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
                 mass * EurekaConfig.SERVER.elevationSnappiness
 
         physShip.applyInvariantForce(Vector3d(0.0,
-            min(engineScaledballoonForceProvided, max(idealUpwardForce, 0.0)) +
+            min(balloonForceProvided, max(idealUpwardForce, 0.0)) +
             // Add drag to the y-component
             vel.y() * -mass,
             0.0)

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -347,17 +347,7 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
     private fun getPlayerUpwardVel(control: ControlData, mass: Double): Vector3d {
         if (control.upImpulse != 0.0f) {
 
-            var balloonForceProvided = balloons * forcePerBalloon
-            if ( EurekaConfig.SERVER.flightRequiresEngine ) {
-                balloonForceProvided = if (extraForceLinear == 0.0) {
-                    0.0 // Divide by 0 case
-                } else {
-                    (balloons * forcePerBalloon) * min(
-                        1.0,
-                        (extraForceLinear / ( EurekaConfig.SERVER.enginePowerLinear * EurekaConfig.SERVER.flightMaxEngines ) ) * (100 / EurekaConfig.SERVER.flightEnginePercentage)
-                    )
-                }
-            }
+            val balloonForceProvided = balloons * forcePerBalloon
 
             return Vector3d(0.0, 1.0, 0.0)
                 .mul(control.upImpulse.toDouble())


### PR DESCRIPTION
A simple change that adds a config option that requires flying ships to have an active engine.

The option is disabled by default to fit the existing Eureka system.

This change is meant for survival worlds where flying ships are currently just undeniably better than making water ships. It is essentially a balancing change intended for multiplayer survival worlds. I have already distributed some custom JARs to some server owners who were interested in this.

It does this by simply refusing to calculate the force applied by balloons unless an engine is currently providing power.

[Video Demonstration](https://cdn.discordapp.com/attachments/1323005693405565040/1323005694839881739/Minecraft_2024.12.29_-_14.03.08.02.mp4?ex=6772f091&is=67719f11&hm=e92e591434b8c70d4a042d4b70c3ce41e0c13a4e2a98fba6f7e1ef4e1309f38f&)