### PR TITLE
Seperate water vs flying ship speeds in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ classes/
 .vscode
 .settings
 *.launch
+.DS_Store

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -109,9 +109,9 @@ object EurekaConfig {
 
         @JsonSchema(
             description = "The maximum distance from center of mass to one end of the ship considered by " +
-                    "the turn speed. At it's default of 16, it ensures that really large ships will turn at the same " +
-                    "speed as a ship with a center of mass only 16 blocks away from the farthest point in the ship. " +
-                    "That way, large ships do not turn painfully slowly"
+                "the turn speed. At it's default of 16, it ensures that really large ships will turn at the same " +
+                "speed as a ship with a center of mass only 16 blocks away from the farthest point in the ship. " +
+                "That way, large ships do not turn painfully slowly"
         )
         var maxSizeForTurnSpeedPenalty = 16.0
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -55,11 +55,11 @@ object EurekaConfig {
         @JsonSchema(description = "The final linear boost will be raised to the power of 2, and the result of the delta is multiple by this value")
         val engineBoostExponentialPower = 0.000001
 
-        @JsonSchema(description = "Max speed of a ship on water or lava without boosting")
-        val maxCasualWaterSpeed = 20.0
-
         @JsonSchema(description = "Max speed of a flying ship without boosting")
         val maxCasualAirSpeed = 15.0
+
+        @JsonSchema(description = "Max speed of a ship on water or lava without boosting")
+        val maxCasualWaterSpeed = 20.0
 
         @JsonSchema(description = "The speed at which the ship stabilizes")
         var stabilizationSpeed = 10.0

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -55,8 +55,11 @@ object EurekaConfig {
         @JsonSchema(description = "The final linear boost will be raised to the power of 2, and the result of the delta is multiple by this value")
         val engineBoostExponentialPower = 0.000001
 
-        @JsonSchema(description = "Max speed of a ship without boosting")
-        val maxCasualSpeed = 15.0
+        @JsonSchema(description = "Max speed of a ship on water or lava without boosting")
+        val maxCasualWaterSpeed = 20.0
+
+        @JsonSchema(description = "Max speed of a flying ship without boosting")
+        val maxCasualAirSpeed = 15.0
 
         @JsonSchema(description = "The speed at which the ship stabilizes")
         var stabilizationSpeed = 10.0
@@ -106,9 +109,9 @@ object EurekaConfig {
 
         @JsonSchema(
             description = "The maximum distance from center of mass to one end of the ship considered by " +
-                "the turn speed. At it's default of 16, it ensures that really large ships will turn at the same " +
-                "speed as a ship with a center of mass only 16 blocks away from the farthest point in the ship. " +
-                "That way, large ships do not turn painfully slowly"
+                    "the turn speed. At it's default of 16, it ensures that really large ships will turn at the same " +
+                    "speed as a ship with a center of mass only 16 blocks away from the farthest point in the ship. " +
+                    "That way, large ships do not turn painfully slowly"
         )
         var maxSizeForTurnSpeedPenalty = 16.0
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -142,8 +142,11 @@ object EurekaConfig {
         @JsonSchema(description = "Max smoothing value, will smooth out before reaching max value.")
         var linearMaxMass = 10000.0
 
-        @JsonSchema(description = "Max unscaled speed in m/s.")
-        var linearMaxSpeed = 15.0
+        @JsonSchema(description = "Max unscaled speed for a flying ship in m/s.")
+        var linearMaxAirSpeed = 15.0
+
+        @JsonSchema(description = "Max unscaled speed for a ship floating in water/lava in m/s.")
+        var linearMaxWaterSpeed = 20.0
 
         // Anti-velocity mass relevance when stopping the ship
         // Max 10.0 (means no mass irrelevance)

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -55,11 +55,11 @@ object EurekaConfig {
         @JsonSchema(description = "The final linear boost will be raised to the power of 2, and the result of the delta is multiple by this value")
         val engineBoostExponentialPower = 0.000001
 
-        @JsonSchema(description = "Max speed of a flying ship without boosting")
-        val maxCasualAirSpeed = 15.0
+        @JsonSchema(description = "How the maximum speed of an airship should compare to one on water")
+        val airSpeedMultiplier = 0.75
 
         @JsonSchema(description = "Max speed of a ship on water or lava without boosting")
-        val maxCasualWaterSpeed = 20.0
+        val maxCasualSpeed = 20.0
 
         @JsonSchema(description = "The speed at which the ship stabilizes")
         var stabilizationSpeed = 10.0
@@ -142,11 +142,8 @@ object EurekaConfig {
         @JsonSchema(description = "Max smoothing value, will smooth out before reaching max value.")
         var linearMaxMass = 10000.0
 
-        @JsonSchema(description = "Max unscaled speed for a flying ship in m/s.")
-        var linearMaxAirSpeed = 15.0
-
         @JsonSchema(description = "Max unscaled speed for a ship floating in water/lava in m/s.")
-        var linearMaxWaterSpeed = 20.0
+        var linearMaxSpeed = 20.0
 
         // Anti-velocity mass relevance when stopping the ship
         // Max 10.0 (means no mass irrelevance)

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -305,7 +305,12 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
             physShip.mass * EurekaConfig.SERVER.linearMassScaling + EurekaConfig.SERVER.linearBaseMass
         )
 
-        val maxSpeed = EurekaConfig.SERVER.linearMaxSpeed / 15
+        // Max speed depends on ship type
+        var maxSpeed = EurekaConfig.SERVER.linearMaxAirSpeed / 15
+        if ( balloonForceProvided == 0.0 ) {
+            maxSpeed = EurekaConfig.SERVER.linearMaxWaterSpeed / 15
+        }
+        
         oldSpeed = max(min(oldSpeed * (1 - s) + control.forwardImpulse.toDouble() * s, maxSpeed), -maxSpeed)
         forwardVector.mul(oldSpeed)
 
@@ -321,8 +326,12 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
             val boost = max((extraForceLinear - EurekaConfig.SERVER.enginePowerLinear * EurekaConfig.SERVER.engineBoostOffset) * EurekaConfig.SERVER.engineBoost, 0.0)
             extraForceLinear += boost + boost * boost * EurekaConfig.SERVER.engineBoostExponentialPower
 
-            // This is the maximum speed we want to go in any scenario (when not sprinting)
-            val idealForwardVel = Vector3d(forwardVector).mul(EurekaConfig.SERVER.maxCasualSpeed)
+            // This is the maximum speed we want to go in any scenario (when not sprinting) based on ship type
+            var idealForwardVel = Vector3d(forwardVector).mul(EurekaConfig.SERVER.maxCasualAirSpeed)
+            if ( balloonForceProvided == 0.0 ) {
+                idealForwardVel = Vector3d(forwardVector).mul(EurekaConfig.SERVER.maxCasualWaterSpeed)
+            }
+            
             val idealForwardForce = Vector3d(idealForwardVel).sub(velOrthogonalToPlayerUp).mul(scaledMass)
 
             val extraForceNeeded = Vector3d(idealForwardForce).sub(forwardForce)

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/ship/EurekaShipControl.kt
@@ -305,10 +305,12 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
             physShip.mass * EurekaConfig.SERVER.linearMassScaling + EurekaConfig.SERVER.linearBaseMass
         )
 
+        val balloonForceProvided = balloons * forcePerBalloon // TODO: Replace with new engine algorithm (see engine-required branch)
+
         // Max speed depends on ship type
-        var maxSpeed = EurekaConfig.SERVER.linearMaxAirSpeed / 15
-        if ( balloonForceProvided == 0.0 ) {
-            maxSpeed = EurekaConfig.SERVER.linearMaxWaterSpeed / 15
+        var maxSpeed = EurekaConfig.SERVER.linearMaxSpeed / 15
+        if ( balloonForceProvided != 0.0 ) {
+            maxSpeed *= EurekaConfig.SERVER.airSpeedMultiplier
         }
         
         oldSpeed = max(min(oldSpeed * (1 - s) + control.forwardImpulse.toDouble() * s, maxSpeed), -maxSpeed)
@@ -327,9 +329,9 @@ class EurekaShipControl : ShipForcesInducer, ServerTickListener {
             extraForceLinear += boost + boost * boost * EurekaConfig.SERVER.engineBoostExponentialPower
 
             // This is the maximum speed we want to go in any scenario (when not sprinting) based on ship type
-            var idealForwardVel = Vector3d(forwardVector).mul(EurekaConfig.SERVER.maxCasualAirSpeed)
-            if ( balloonForceProvided == 0.0 ) {
-                idealForwardVel = Vector3d(forwardVector).mul(EurekaConfig.SERVER.maxCasualWaterSpeed)
+            var idealForwardVel = Vector3d(forwardVector).mul(EurekaConfig.SERVER.maxCasualSpeed)
+            if ( balloonForceProvided != 0.0 ) {
+                idealForwardVel.mul(EurekaConfig.SERVER.airSpeedMultiplier)
             }
             
             val idealForwardForce = Vector3d(idealForwardVel).sub(velOrthogonalToPlayerUp).mul(scaledMass)


### PR DESCRIPTION
This change allows server owners to change water and airship speeds independently. It is effectively a balancing change to make it more reasonable and practical to build a water ship as compared to a flying ship.

By default, this would make ships floating on water/lava up to 5 m/s faster, which I think is a fair way to encourage these the difference in these ships.

A ship's state is determined by whether or not it has functional balloons.