### PR TITLE
Add config to pop balloons in the nether

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ classes/
 .vscode
 .settings
 *.launch
+.DS_Store

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -151,6 +151,9 @@ object EurekaConfig {
         @JsonSchema(description = "Chance for popped balloons to pop adjacent balloons, per side")
         var popSideBalloonChance = 0.3
 
+        @JsonSchema(description = "Balloons pop immediately when placed in the Nether")
+        var balloonsPopInNether = false
+
         @JsonSchema(description = "Whether the ship helm assembles diagonally connected blocks or not")
         val diagonals = true
 

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -151,8 +151,13 @@ object EurekaConfig {
         @JsonSchema(description = "Chance for popped balloons to pop adjacent balloons, per side")
         var popSideBalloonChance = 0.3
 
-        @JsonSchema(description = "Balloons pop immediately when placed in the Nether")
+        @JsonSchema(description = "Balloons pop immediately when placed in certain dimensions, defined in the Balloon Dimension Blacklist")
         var balloonsPopInNether = false
+
+        @JsonSchema(description = "Dimensions where balloons cannot be placed when Balloons Pop In Nether is enabled")
+        var balloonDimensionBlacklist = setOf(
+            "minecraft:the_nether"
+        )
 
         @JsonSchema(description = "Whether the ship helm assembles diagonally connected blocks or not")
         val diagonals = true

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -151,12 +151,8 @@ object EurekaConfig {
         @JsonSchema(description = "Chance for popped balloons to pop adjacent balloons, per side")
         var popSideBalloonChance = 0.3
 
-        @JsonSchema(description = "Balloons pop immediately when placed in certain dimensions, defined in the Balloon Dimension Blacklist")
-        var balloonsPopInNether = false
-
         @JsonSchema(description = "List of dimensions where balloons pop immediately, e.g: minecraft:the_nether")
         var balloonDimensionBlacklist = setOf(
-            "minecraft:the_nether"
         )
 
         @JsonSchema(description = "Whether the ship helm assembles diagonally connected blocks or not")

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -151,9 +151,8 @@ object EurekaConfig {
         @JsonSchema(description = "Chance for popped balloons to pop adjacent balloons, per side")
         var popSideBalloonChance = 0.3
 
-        @JsonSchema(description = "List of dimensions where balloons pop immediately, e.g: minecraft:the_nether")
-        var balloonDimensionBlacklist = setOf(
-        )
+        @JsonSchema(description = "List of dimensions where balloons pop immediately, e.g: \"minecraft:the_nether\"")
+        var balloonDimensionBlacklist: Set<String> = setOf()
 
         @JsonSchema(description = "Whether the ship helm assembles diagonally connected blocks or not")
         val diagonals = true

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/EurekaConfig.kt
@@ -154,7 +154,7 @@ object EurekaConfig {
         @JsonSchema(description = "Balloons pop immediately when placed in certain dimensions, defined in the Balloon Dimension Blacklist")
         var balloonsPopInNether = false
 
-        @JsonSchema(description = "Dimensions where balloons cannot be placed when Balloons Pop In Nether is enabled")
+        @JsonSchema(description = "List of dimensions where balloons pop immediately, e.g: minecraft:the_nether")
         var balloonDimensionBlacklist = setOf(
             "minecraft:the_nether"
         )

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -15,6 +15,12 @@ import org.valkyrienskies.eureka.EurekaConfig
 import org.valkyrienskies.eureka.ship.EurekaShipControl
 import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.getShipObjectManagingPos
+import org.valkyrienskies.mod.util.logger
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.core.particles.ParticleTypes
+import net.minecraft.sounds.SoundEvents
+import net.minecraft.sounds.SoundSource
+import net.minecraft.world.level.block.Blocks
 
 class BalloonBlock(properties: Properties) : Block(properties) {
 
@@ -27,6 +33,9 @@ class BalloonBlock(properties: Properties) : Block(properties) {
 
         if (level.isClientSide) return
         val serverLevel = level as ServerLevel
+
+        val ship = level.getShipObjectManagingPos(pos) ?: level.getShipManagingPos(pos) ?: return
+        EurekaShipControl.getOrCreate(ship).balloons += 1
 
         val invalidDimensionsConfig = EurekaConfig.SERVER.balloonDimensionBlacklist
         val invalidDimensionLocations = invalidDimensionsConfig.mapNotNull { dimensionString ->
@@ -63,9 +72,6 @@ class BalloonBlock(properties: Properties) : Block(properties) {
                 1.0f, // Volume
                 1.0f  // Pitch
             )
-        } else {
-            val ship = level.getShipObjectManagingPos(pos) ?: level.getShipManagingPos(pos) ?: return
-            EurekaShipControl.getOrCreate(ship).balloons += 1
         }
         
     }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -34,8 +34,10 @@ class BalloonBlock(properties: Properties) : Block(properties) {
         if (level.isClientSide) return
         val serverLevel = level as ServerLevel
 
-        val ship = level.getShipObjectManagingPos(pos) ?: level.getShipManagingPos(pos) ?: return
-        EurekaShipControl.getOrCreate(ship).balloons += 1
+        val ship = level.getShipObjectManagingPos(pos) ?: level.getShipManagingPos(pos)
+        if (ship != null) {
+            EurekaShipControl.getOrCreate(ship).balloons += 1
+        }
 
         val invalidDimensionsConfig = EurekaConfig.SERVER.balloonDimensionBlacklist
         val invalidDimensionLocations = invalidDimensionsConfig.mapNotNull { dimensionString ->

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -40,7 +40,29 @@ class BalloonBlock(properties: Properties) : Block(properties) {
         val currentDimensionLocation = serverLevel.dimension().location()
 
         if ( invalidDimensionLocations.contains(currentDimensionLocation) && EurekaConfig.SERVER.balloonsPopInNether ) {
-            serverLevel.destroyBlock(pos, false)
+            // Replace the balloon block with air (Similar to how water is replaced in the Nether)
+            serverLevel.setBlock(pos, Blocks.AIR.defaultBlockState(), 3)
+
+            // Particles
+            serverLevel.sendParticles(
+                ParticleTypes.LARGE_SMOKE,
+                pos.x + 0.5, // Center of the block
+                pos.y + 0.0,
+                pos.z + 0.5,
+                15, // Number of particles per iteration
+                0.1, 0.1, 0.1, // Spread in x, y, z directions
+                0.01 // Speed multiplier
+            )
+
+            // Sounds
+            serverLevel.playSound(
+                null, // No specific player (plays for all nearby players)
+                pos,
+                SoundEvents.LAVA_EXTINGUISH, // Hiss-like sound
+                SoundSource.BLOCKS,
+                1.0f, // Volume
+                1.0f  // Pitch
+            )
         } else {
             val ship = level.getShipObjectManagingPos(pos) ?: level.getShipManagingPos(pos) ?: return
             EurekaShipControl.getOrCreate(ship).balloons += 1

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -51,7 +51,6 @@ class BalloonBlock(properties: Properties) : Block(properties) {
         if ( invalidDimensionLocations.contains(currentDimensionLocation) && EurekaConfig.SERVER.balloonsPopInNether ) {
             // Replace the balloon block with air (Similar to how water is replaced in the Nether)
             serverLevel.setBlock(pos, Blocks.AIR.defaultBlockState(), 3)
-
             // Particles
             serverLevel.sendParticles(
                 ParticleTypes.LARGE_SMOKE,
@@ -62,7 +61,6 @@ class BalloonBlock(properties: Properties) : Block(properties) {
                 0.1, 0.1, 0.1, // Spread in x, y, z directions
                 0.01 // Speed multiplier
             )
-
             // Sounds
             serverLevel.playSound(
                 null, // No specific player (plays for all nearby players)
@@ -73,7 +71,6 @@ class BalloonBlock(properties: Properties) : Block(properties) {
                 1.0f  // Pitch
             )
         }
-        
     }
 
     override fun onRemove(state: BlockState, level: Level, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
@@ -100,4 +97,6 @@ class BalloonBlock(properties: Properties) : Block(properties) {
             }
         }
     }
+
+    private val logger by logger()
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -26,10 +26,14 @@ class BalloonBlock(properties: Properties) : Block(properties) {
         super.onPlace(state, level, pos, oldState, isMoving)
 
         if (level.isClientSide) return
-        level as ServerLevel
-
-        val ship = level.getShipObjectManagingPos(pos) ?: level.getShipManagingPos(pos) ?: return
-        EurekaShipControl.getOrCreate(ship).balloons += 1
+        val serverLevel = level as ServerLevel
+        
+        if (serverLevel.dimension() == Level.NETHER && EurekaConfig.SERVER.balloonsPopInNether) {
+            serverLevel.destroyBlock(pos, false)
+        } else {
+            val ship = level.getShipObjectManagingPos(pos) ?: level.getShipManagingPos(pos) ?: return
+            EurekaShipControl.getOrCreate(ship).balloons += 1
+        }
     }
 
     override fun onRemove(state: BlockState, level: Level, pos: BlockPos, newState: BlockState, isMoving: Boolean) {

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -15,7 +15,6 @@ import org.valkyrienskies.eureka.EurekaConfig
 import org.valkyrienskies.eureka.ship.EurekaShipControl
 import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.getShipObjectManagingPos
-import org.valkyrienskies.mod.util.logger
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.sounds.SoundEvents
@@ -45,7 +44,6 @@ class BalloonBlock(properties: Properties) : Block(properties) {
                 try {
                     ResourceLocation(dimensionString)
                 } catch (e: Exception) {
-                    logger.warn("Invalid dimension string: $dimensionString")
                     null
                 }
             }.toSet()
@@ -100,6 +98,5 @@ class BalloonBlock(properties: Properties) : Block(properties) {
             }
         }
     }
-
-    private val logger by logger()
+    
 }

--- a/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/eureka/block/BalloonBlock.kt
@@ -40,38 +40,39 @@ class BalloonBlock(properties: Properties) : Block(properties) {
         }
 
         val invalidDimensionsConfig = EurekaConfig.SERVER.balloonDimensionBlacklist
-        val invalidDimensionLocations = invalidDimensionsConfig.mapNotNull { dimensionString ->
-            try {
-                ResourceLocation(dimensionString)
-            } catch (e: Exception) {
-                logger.warn("Invalid dimension string: $dimensionString")
-                null
+        if ( invalidDimensionsConfig.isNotEmpty() ) {
+            val invalidDimensionLocations = invalidDimensionsConfig.mapNotNull { dimensionString ->
+                try {
+                    ResourceLocation(dimensionString)
+                } catch (e: Exception) {
+                    logger.warn("Invalid dimension string: $dimensionString")
+                    null
+                }
+            }.toSet()
+            val currentDimensionLocation = serverLevel.dimension().location()
+            if ( invalidDimensionLocations.contains(currentDimensionLocation) ) {
+                // Replace the balloon block with air (Similar to how water is replaced in the Nether)
+                serverLevel.setBlock(pos, Blocks.AIR.defaultBlockState(), 3)
+                // Particles
+                serverLevel.sendParticles(
+                    ParticleTypes.LARGE_SMOKE,
+                    pos.x + 0.5, // Center of the block
+                    pos.y + 0.0,
+                    pos.z + 0.5,
+                    15, // Number of particles per iteration
+                    0.1, 0.1, 0.1, // Spread in x, y, z directions
+                    0.01 // Speed multiplier
+                )
+                // Sounds
+                serverLevel.playSound(
+                    null, // No specific player (plays for all nearby players)
+                    pos,
+                    SoundEvents.LAVA_EXTINGUISH, // Hiss-like sound
+                    SoundSource.BLOCKS,
+                    1.0f, // Volume
+                    1.0f  // Pitch
+                )
             }
-        }.toSet()
-        val currentDimensionLocation = serverLevel.dimension().location()
-
-        if ( invalidDimensionLocations.contains(currentDimensionLocation) && EurekaConfig.SERVER.balloonsPopInNether ) {
-            // Replace the balloon block with air (Similar to how water is replaced in the Nether)
-            serverLevel.setBlock(pos, Blocks.AIR.defaultBlockState(), 3)
-            // Particles
-            serverLevel.sendParticles(
-                ParticleTypes.LARGE_SMOKE,
-                pos.x + 0.5, // Center of the block
-                pos.y + 0.0,
-                pos.z + 0.5,
-                15, // Number of particles per iteration
-                0.1, 0.1, 0.1, // Spread in x, y, z directions
-                0.01 // Speed multiplier
-            )
-            // Sounds
-            serverLevel.playSound(
-                null, // No specific player (plays for all nearby players)
-                pos,
-                SoundEvents.LAVA_EXTINGUISH, // Hiss-like sound
-                SoundSource.BLOCKS,
-                1.0f, // Volume
-                1.0f  // Pitch
-            )
         }
     }
 


### PR DESCRIPTION
If a balloon is placed in the nether with the config enabled, it immediately destroys itself exactly as it would if a projectile hit it, and does not report that a balloon was added to the ship.

No change if the config is disabled.

Another balancing change to make the nether a more hostile environment in survival worlds. While it still allows for the creation of ships, it effectively limits these ships to lava lakes, instead of simply allowing you to park your mobile base on top of a nether fortress and feel safe.

Config is disabled by default.